### PR TITLE
Add private package support

### DIFF
--- a/lib/commands/bootstrap.js
+++ b/lib/commands/bootstrap.js
@@ -43,13 +43,14 @@ exports.execute = function (config) {
 
       tasks.push(function (done) {
         async.each(packages, function (sub, done) {
+          var priv = root.pkg.private || false;
           var ver = false;
           if (root.pkg.dependencies) ver = root.pkg.dependencies[sub.name];
           if (root.pkg.devDependencies && !ver) ver = root.pkg.devDependencies[sub.name];
           if (!ver) return done();
 
           // ensure that this is referring to a local package
-          if (ver[0] !== "^" || ver[1] !== config.currentVersion[0]) return done();
+          if (!priv && (ver[0] !== "^" || ver[1] !== config.currentVersion[0])) return done();
 
           var linkSrc = path.join(config.packagesLoc, sub.folder);
           var linkDest = path.join(nodeModulesLoc, sub.name);


### PR DESCRIPTION
I am looking to use lerna to manage our monorepo, but we don't have packages published on `npm`. This causes `npm install` to fail on `lerna bootstrap` because the package was not found on the registry. 

I added a simple check to see if `private: true` is set in `package.json`. I am not sure if this is the best way to do it because it bypasses the version check. However, in my case I don't have a version because my dependencies look like this:

```
# packages/some-other-package/package.json
  "dependencies": {
    "some-local-dependency": "file:../some-local-dependency"
  },
```

Is there a better way to do this?
