### PR TITLE
Command to show what packages will be updated

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,38 @@
+{
+  "extends": "eslint:recommended",
+  "rules": {
+    "quotes": [
+      2,
+      "double",
+      "avoid-escape"
+    ],
+    "no-var": 0,
+    "space-after-keywords": 2,
+    "strict": 0,
+    "no-underscore-dangle": 0,
+    "curly": 0,
+    "no-multi-spaces": 0,
+    "key-spacing": 0,
+    "no-return-assign": 0,
+    "consistent-return": 0,
+    "no-shadow": 0,
+    "comma-dangle": 0,
+    "no-use-before-define": 0,
+    "no-empty": 0,
+    "new-parens": 0,
+    "no-cond-assign": 0,
+    "no-fallthrough": 0,
+    "new-cap": 0,
+    "no-loop-func": 0,
+    "no-unreachable": 0,
+    "no-labels": 0,
+    "no-process-exit": 0,
+    "camelcase": 0,
+    "no-console": 0,
+    "no-constant-condition": 0,
+    "no-inner-declarations": 0
+  },
+  "env": {
+    "node": true
+  }
+}

--- a/.travis.yaml
+++ b/.travis.yaml
@@ -1,0 +1,15 @@
+---
+git:
+  depth: 1
+sudo: false
+language: node_js
+cache:
+  directories:
+  - node_modules
+
+node_js:
+ - "0.10"
+ - "0.12"
+ - stable
+
+script: npm run ci

--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ $ lerna bootstrap
 1. Link together all packages that depend on each other.
 2. `npm install` all other dependencies of each package.
 
+### Updated
+
+```sh
+$ lerna updated
+```
+
+1. Checks which `packages` have changed since the last release" and logs it.
+
 ### Publishing
 
 ```sh

--- a/lib/commands/bootstrap.js
+++ b/lib/commands/bootstrap.js
@@ -5,7 +5,6 @@ var chalk       = require("chalk");
 var child       = require("child_process");
 var async       = require("async");
 var path        = require("path");
-var pad         = require("pad");
 var fs          = require("fs");
 
 exports.description = "Link together local packages and npm install remaining package dependencies";
@@ -66,7 +65,7 @@ exports.execute = function (config) {
               }, null, "  "), function (err) {
                 if (err) return done(err);
 
-                fs.writeFile(path.join(linkDest, "index.js"), 'module.exports = require(' + JSON.stringify(linkSrc) + ');', done);
+                fs.writeFile(path.join(linkDest, "index.js"), "module.exports = require(" + JSON.stringify(linkSrc) + ");", done);
               });
             });
           });

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -1,2 +1,3 @@
 exports.bootstrap = require("./bootstrap");
 exports.publish   = require("./publish");
+exports.updated   = require("./updated");

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -1,10 +1,13 @@
 var progressBar = require("../progress-bar");
+var updated     = require("./updated");
 var readline    = require("readline-sync");
 var semver      = require("semver");
 var chalk       = require("chalk");
 var child       = require("child_process");
 var async       = require("async");
 var fs          = require("fs");
+
+var checkUpdatedPackages = updated.checkUpdatedPackages;
 
 exports.description = "Publish updated packages to npm";
 
@@ -21,7 +24,9 @@ exports.execute = function (config) {
   //
 
   try {
-    checkUpdatedPackages();
+    changedPackages = checkUpdatedPackages(config);
+    console.log('Packages to be updated');
+    console.log(changedPackages);
     updateChangedPackages();
     updateTag();
     publish();
@@ -73,10 +78,6 @@ exports.execute = function (config) {
     return config.packagesLoc + "/" + name;
   }
 
-  function getPackageConfig(name) {
-    return require(getPackageLocation(name) + "/package.json");
-  }
-
   function updateDepsObject(deps) {
     for (var depName in deps) {
       // ensure this was generated and we're on the same major
@@ -85,38 +86,6 @@ exports.execute = function (config) {
       if (changedPackages.indexOf(depName) >= 0) {
         deps[depName] = "^" + NEW_VERSION;
       }
-    }
-  }
-
-  function checkUpdatedPackages() {
-    console.log("Checking packages...");
-
-    var packageNames = fs.readdirSync(config.packagesLoc).filter(function (name) {
-      return name[0] !== "." && fs.statSync(config.packagesLoc + "/" + name).isDirectory();
-    });
-
-    var tick = progressBar(packageNames.length);
-
-    var lastTagCommit = execSync("git rev-list --tags --max-count=1");
-    var lastTag       = execSync("git describe " + lastTagCommit);
-
-    packageNames.forEach(function (name) {
-      var config = getPackageConfig(name);
-      tick(name);
-
-      if (config.private) return;
-
-      // check if package has changed since last release
-      var diff = FORCE_VERSION.indexOf("*") >= 0 || FORCE_VERSION.indexOf(name) >= 0 ||
-                 execSync("git diff " + lastTag + " -- " + getPackageLocation(name));
-      if (diff) {
-        changedPackages.push(name);
-      }
-    });
-
-    if (!changedPackages.length && !FORCE_VERSION.length) {
-      console.error(chalk.red("No updated packages to publish."));
-      process.exit(1);
     }
   }
 
@@ -208,7 +177,6 @@ exports.execute = function (config) {
 
     async.parallelLimit(changedPackages.map(function (name) {
       return function (done) {
-        var loc = getPackageLocation(name);
         while (true) {
           try {
             execSync("npm dist-tag rm " + name + " prerelease");

--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -25,8 +25,10 @@ exports.execute = function (config) {
 
   try {
     changedPackages = checkUpdatedPackages(config);
-    console.log('Packages to be updated');
-    console.log(changedPackages);
+    console.log("Packages to be updated");
+    console.log(changedPackages.map(function(pkg) {
+      return "- " + pkg;
+    }).join("\n"));
     updateChangedPackages();
     updateTag();
     publish();
@@ -196,8 +198,6 @@ exports.execute = function (config) {
       execSync("git push --tags");
       console.log();
       console.log(chalk.green("Successfully published " + NEW_VERSION + "."));
-      console.log("Updated Packages");
-      console.log(changedPackages);
       process.exit();
     });
   }

--- a/lib/commands/updated.js
+++ b/lib/commands/updated.js
@@ -6,7 +6,11 @@ var fs          = require("fs");
 exports.description = "Check which packages have changed since the last release";
 
 exports.execute = function (config) {
-  console.log(exports.checkUpdatedPackages(config));
+  var changedPackages = exports.checkUpdatedPackages(config).map(function(pkg) {
+    return "- " + pkg;
+  }).join("\n");
+
+  console.log(changedPackages);
 }
 
 exports.checkUpdatedPackages = function (config) {

--- a/lib/commands/updated.js
+++ b/lib/commands/updated.js
@@ -1,0 +1,62 @@
+var progressBar = require("../progress-bar");
+var chalk       = require("chalk");
+var child       = require("child_process");
+var fs          = require("fs");
+
+exports.description = "Check which packages have changed since the last release";
+
+exports.execute = function (config) {
+  console.log(exports.checkUpdatedPackages(config));
+}
+
+exports.checkUpdatedPackages = function (config) {
+  var changedPackages = [];
+  var FORCE_VERSION = process.env.FORCE_VERSION;
+  FORCE_VERSION = FORCE_VERSION ? FORCE_VERSION.split(",") : [];
+
+  console.log("Checking packages...");
+
+  var packageNames = fs.readdirSync(config.packagesLoc).filter(function (name) {
+    return name[0] !== "." && fs.statSync(config.packagesLoc + "/" + name).isDirectory();
+  });
+
+  var tick = progressBar(packageNames.length);
+
+  var lastTagCommit = execSync("git rev-list --tags --max-count=1");
+  var lastTag       = execSync("git describe " + lastTagCommit);
+
+  packageNames.forEach(function (name) {
+    var cfg = getPackageConfig(config, name);
+    tick(name);
+
+    if (cfg.private) return;
+
+    // check if package has changed since last release
+    var diff = FORCE_VERSION.indexOf("*") >= 0 || FORCE_VERSION.indexOf(name) >= 0 ||
+               execSync("git diff " + lastTag + " -- " + getPackageLocation(config, name));
+    if (diff) {
+      changedPackages.push(name);
+    }
+  });
+
+  if (!changedPackages.length && !FORCE_VERSION.length) {
+    console.error(chalk.red("No updated packages to publish."));
+    process.exit(1);
+  } else {
+    return changedPackages;
+  }
+}
+
+function getPackageLocation(config, name) {
+  return config.packagesLoc + "/" + name;
+}
+
+function getPackageConfig(config, name) {
+  return require(getPackageLocation(config, name) + "/package.json");
+}
+
+function execSync(cmd) {
+  return child.execSync(cmd, {
+    encoding: "utf8"
+  }).trim();
+}

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.5",
   "description": "Tool for managing JavaScript projects with multiple packages",
   "main": "index.js",
+  "scripts": {
+    "lint": "./node_modules/.bin/eslint lib"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/sebmck/lerna.git"
@@ -25,5 +28,8 @@
   },
   "bin": {
     "lerna": "./bin/lerna.js"
+  },
+  "devDependencies": {
+    "eslint": "^1.10.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Tool for managing JavaScript projects with multiple packages",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint lib"
+    "lint": "./node_modules/.bin/eslint lib",
+    "ci": "npm run lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes https://github.com/kittens/lerna/issues/12

New command: `lerna updated` (open to suggestions for the name: `diff, changed, dryrun`) 
Add linting config from babel

There's some duplicated code (utility functions) that I didn't bother to share.

We should probably just print out the changed packages by default anyway when you run `lerna publish` right? We currently print it at the end.

---

For babel https://github.com/babel/babel/compare/v6.4.4...master

<img width="613" alt="screen shot 2016-01-16 at 10 39 45 pm" src="https://cloud.githubusercontent.com/assets/588473/12375828/eef91e08-bca2-11e5-8bc6-bdd6a40b8021.png">