### PR TITLE
Added support for handling @org/package

### DIFF
--- a/lib/commands/publish.js
+++ b/lib/commands/publish.js
@@ -26,8 +26,8 @@ exports.execute = function (config) {
   try {
     changedPackages = checkUpdatedPackages(config);
     console.log("Packages to be updated");
-    console.log(changedPackages.map(function(pkg) {
-      return "- " + pkg;
+    console.log(changedPackages.map(function(pkgObject) {
+      return "- " + pkgObject.pkgName;
     }).join("\n"));
     updateChangedPackages();
     updateTag();
@@ -92,8 +92,8 @@ exports.execute = function (config) {
   }
 
   function updateChangedPackages() {
-    changedPackages.forEach(function (name) {
-      var pkgLoc = getPackageLocation(name) + "/package.json";
+    changedPackages.forEach(function (pkgObject) {
+      var pkgLoc = getPackageLocation(pkgObject.dirName) + "/package.json";
       var pkg = require(pkgLoc);
 
       // set new version
@@ -116,20 +116,20 @@ exports.execute = function (config) {
   }
 
   function publish() {
-    changedPackages.forEach(function (name) {
+    changedPackages.forEach(function (pkgObject) {
       // prepublish script
-      var prePub = getPackageLocation(name) + "/scripts/prepublish.js";
+      var prePub = getPackageLocation(pkgObject.dirName) + "/scripts/prepublish.js";
       if (fs.existsSync(prePub)) require(prePub);
     });
 
     console.log("Publishing tagged packages...");
     var tick = progressBar(changedPackages.length);
 
-    async.parallelLimit(changedPackages.map(function (name) {
+    async.parallelLimit(changedPackages.map(function (pkgObject) {
       var retries = 0;
 
       return function run(done) {
-        var loc = getPackageLocation(name);
+        var loc = getPackageLocation(pkgObject.dirName);
 
         child.exec("cd " + loc + " && npm publish --tag prerelease", function (err, stdout, stderr) {
           if (err || stderr) {
@@ -148,7 +148,7 @@ exports.execute = function (config) {
             }
           }
 
-          tick(name);
+          tick(pkgObject.dirName);
 
           // postpublish script
           var postPub = loc + "/scripts/postpublish.js";
@@ -177,14 +177,14 @@ exports.execute = function (config) {
     console.log("Setting latest npm tags...");
     var tick = progressBar(changedPackages.length);
 
-    async.parallelLimit(changedPackages.map(function (name) {
+    async.parallelLimit(changedPackages.map(function (pkgObject) {
       return function (done) {
         while (true) {
           try {
-            execSync("npm dist-tag rm " + name + " prerelease");
-            execSync("npm dist-tag add " + name + "@" + NEW_VERSION + " stable");
-            execSync("npm dist-tag add " + name + "@" + NEW_VERSION + " latest");
-            tick(name);
+            execSync("npm dist-tag rm " + pkgObject.pkgName + " prerelease");
+            execSync("npm dist-tag add " + pkgObject.pkgName + "@" + NEW_VERSION + " stable");
+            execSync("npm dist-tag add " + pkgObject.pkgName + "@" + NEW_VERSION + " latest");
+            tick(pkgObject.dirName);
             break;
           } catch (err) {
             console.error(err.stack);
@@ -194,7 +194,7 @@ exports.execute = function (config) {
       };
     }), 4, function (err) {
       onError(err);
-      execSync("git push");
+      execSync("git push origin master");
       execSync("git push --tags");
       console.log();
       console.log(chalk.green("Successfully published " + NEW_VERSION + "."));

--- a/lib/commands/updated.js
+++ b/lib/commands/updated.js
@@ -2,6 +2,8 @@ var progressBar = require("../progress-bar");
 var chalk       = require("chalk");
 var child       = require("child_process");
 var fs          = require("fs");
+var path        = require("path");
+var log         = require("debug")("lerna:updated");
 
 exports.description = "Check which packages have changed since the last release";
 
@@ -20,11 +22,11 @@ exports.checkUpdatedPackages = function (config) {
 
   console.log("Checking packages...");
 
-  var packageNames = fs.readdirSync(config.packagesLoc).filter(function (name) {
+  var packageDirNames = fs.readdirSync(config.packagesLoc).filter(function (name) {
     return name[0] !== "." && fs.statSync(config.packagesLoc + "/" + name).isDirectory();
   });
 
-  var tick = progressBar(packageNames.length);
+  var tick = progressBar(packageDirNames.length);
 
   var hasTags = !!execSync("git tags");
   var lastTagCommit;
@@ -35,24 +37,32 @@ exports.checkUpdatedPackages = function (config) {
     lastTag = execSync("git describe " + lastTagCommit);
   }
 
-  packageNames.forEach(function (name) {
-    var cfg = getPackageConfig(config, name);
-    tick(name);
+  packageDirNames.forEach(function (pkgDirName) {
+    var cfg = getPackageConfig(config, pkgDirName);
+    tick(pkgDirName);
 
     if (cfg.private) return;
 
+    var pkgObject = {
+      dirName: pkgDirName,
+      pkgName: cfg.name
+    };
+
     if (!hasTags) {
-      changedPackages.push(name);
+      changedPackages.push(pkgObject);
       return;
     }
 
     // check if package has changed since last release
-    var diff = FORCE_VERSION.indexOf("*") >= 0 || FORCE_VERSION.indexOf(name) >= 0 ||
-               execSync("git diff " + lastTag + " -- " + getPackageLocation(config, name));
+    var diff = FORCE_VERSION.indexOf("*") >= 0 || FORCE_VERSION.indexOf(pkgDirName) >= 0 ||
+               execSync("git diff " + lastTag + " -- " + getPackageLocation(config, pkgDirName));
+
     if (diff) {
-      changedPackages.push(name);
+      changedPackages.push(pkgObject);
     }
   });
+
+  log("dectected packages for update (%s)", changedPackages.map(function (obj) { return obj.pkgName}).join(","));
 
   if (!changedPackages.length && !FORCE_VERSION.length) {
     console.error(chalk.red("No updated packages to publish."));
@@ -63,11 +73,11 @@ exports.checkUpdatedPackages = function (config) {
 }
 
 function getPackageLocation(config, name) {
-  return config.packagesLoc + "/" + name;
+  return path.join(config.packagesLoc, name);
 }
 
 function getPackageConfig(config, name) {
-  return require(getPackageLocation(config, name) + "/package.json");
+  return require(path.join(getPackageLocation(config, name), "package.json"));
 }
 
 function execSync(cmd) {

--- a/lib/init.js
+++ b/lib/init.js
@@ -29,7 +29,7 @@ module.exports = function (cmd, cwd) {
     }, null, "  "));
   }
 
-  config.versionLoc  = path.join(cwd, "VERSION");
+  config.versionLoc = path.join(cwd, "VERSION");
 
   if (fs.existsSync(config.versionLoc)) {
     config.currentVersion = fs.readFileSync(config.versionLoc, "utf8").trim();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lerna",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Tool for managing JavaScript projects with multiple packages",
   "main": "index.js",
   "scripts": {
@@ -20,6 +20,7 @@
   "dependencies": {
     "async": "^1.5.0",
     "chalk": "^1.1.1",
+    "debug": "^2.2.0",
     "mkdirp": "^0.5.1",
     "pad": "^1.0.0",
     "progress": "^1.1.8",


### PR DESCRIPTION
Hey everyone!

I was having problems with packages which are not named as the folder containing the code (my personal scenario are scoped packages). So instead of use the folder's name for everything, I'm using the `package.json{name}` when running `npm dist-tag`.

Do you think we could do something to handle this scenario?

Any feedback will be welcome!
