### PR TITLE
Fix linking

### DIFF
--- a/lib/commands/bootstrap/linkDependencies.js
+++ b/lib/commands/bootstrap/linkDependencies.js
@@ -32,6 +32,10 @@ module.exports = function linkDependencies(packages, packagesLoc, currentVersion
       });
 
       tasks.push(function (done) {
+        npmInstallInDir(packageLoc, done);
+      });
+
+      tasks.push(function (done) {
         linkDependenciesForPackage(
           root.pkg,
           packages,
@@ -40,10 +44,6 @@ module.exports = function linkDependencies(packages, packagesLoc, currentVersion
           currentVersion,
           done
         );
-      });
-
-      tasks.push(function (done) {
-        npmInstallInDir(packageLoc, done);
       });
 
       tasks.push(function (done) {


### PR DESCRIPTION
For some reason npm is installing right over the "linked" files, I'm not sure how this was working previously, but it seems that npm install should occur before linking.