### PR TITLE
Fix for signal-exit hanging

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -16,6 +16,8 @@ var cli = meow([
   ""
 ]);
 
+require("signal-exit").unload();
+
 var commandName = cli.input[0];
 var command = commands[commandName];
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "progress": "^1.1.8",
     "readline-sync": "^1.2.21",
     "rimraf": "^2.4.4",
-    "semver": "^5.1.0"
+    "semver": "^5.1.0",
+    "signal-exit": "^2.1.2"
   },
   "bin": {
     "lerna": "./bin/lerna.js"


### PR DESCRIPTION
`meow` uses `loud-rejection` which uses `signal-exit` which uses `process.on('SIGSEGV', ...)` which has this problem with `readline-sync` https://github.com/anseki/readline-sync/issues/29.

This PR unloads `signal-exit` after `meow` loads it.