### PR TITLE
Detect changes in packages with @ prefix

### DIFF
--- a/lib/utils/checkUpdatedPackages.js
+++ b/lib/utils/checkUpdatedPackages.js
@@ -38,7 +38,7 @@ module.exports = function checkUpdatedPackages(packagesLoc) {
 
     // check if package has changed since last release
     var diff = FORCE_VERSION.indexOf("*") >= 0 || FORCE_VERSION.indexOf(pkg.name) >= 0 ||
-               execSync("git diff " + lastTag + " -- " + getPackageLocation(packagesLoc, pkg.name));
+               execSync("git diff " + lastTag + " -- " + getPackageLocation(packagesLoc, pkg.folder));
     if (diff) {
       changedPackages.push(pkg);
     }


### PR DESCRIPTION
If a package's name is `@org/foo`, the script was trying to diff on the folder at `packages/@org/foo`, which doesn't work for obvious reasons.

This change makes sure we're using the folder name (`foo` in this example) for the diff, not the package's name.