### PR TITLE
Switch to publishing temp tag instead of "prerelease"

### DIFF
--- a/lib/commands/publish/npmPublishAsTemp.js
+++ b/lib/commands/publish/npmPublishAsTemp.js
@@ -39,7 +39,7 @@ module.exports = function npmPublishAsPrerelease(packages, packagesLoc, callback
     return function run(done) {
       var loc = getPackageLocation(packagesLoc, pkg.folder);
 
-      child.exec("cd " + loc + " && npm publish --tag prerelease", function (err, stdout, stderr) {
+      child.exec("cd " + loc + " && npm publish --tag lerna-temp", function (err, stdout, stderr) {
         if (err || stderr) {
           err = stderr || err.stack;
           if (err.indexOf("You cannot publish over the previously published version") < 0) {

--- a/lib/commands/publish/npmPublishSemiAtomic.js
+++ b/lib/commands/publish/npmPublishSemiAtomic.js
@@ -1,9 +1,9 @@
-var npmPublishAsPrerelease = require("./npmPublishAsPrerelease");
-var npmUpdateAsLatest      = require("./npmUpdateAsLatest");
+var npmUpdateAsLatest = require("./npmUpdateAsLatest");
+var npmPublishAsTemp  = require("./npmPublishAsTemp");
 
 module.exports = function npmPublishSemiAtomic(packages, packagesLoc, version, callback) {
   // Start by publishing a prerelease that we'll bump later to be more atomic
-  npmPublishAsPrerelease(packages, packagesLoc, function (err) {
+  npmPublishAsTemp(packages, packagesLoc, function (err) {
     if (err) return callback(err);
 
     // Now that we've successfully published a prerelease set it as the latest

--- a/lib/commands/publish/npmUpdateAsLatest.js
+++ b/lib/commands/publish/npmUpdateAsLatest.js
@@ -11,8 +11,8 @@ module.exports = function npmUpdateAsLatest(changedPackages, version, callback) 
     return function (done) {
       while (true) {
         try {
-          console.log("Removing prerelease npm dist-tag");
-          execSync("npm dist-tag rm " + pkg.name + " prerelease");
+          console.log("Removing temporary npm dist-tag");
+          execSync("npm dist-tag rm " + pkg.name + " lerna-temp");
           if (process.env.NPM_DIST_TAG) {
             console.log("Adding " + process.env.NPM_DIST_TAG + " npm dist-tag");
             execSync("npm dist-tag add " + pkg.name + "@" + version + " " + process.env.NPM_DIST_TAG);


### PR DESCRIPTION
Thought I'd open this to discuss since we were talking about pre-releases elsewhere and theres no reason we need to override the "prerelease" tag.