### PR TITLE
Push version tags explicitly

### DIFF
--- a/lib/commands/publish/publishChangedPackages.js
+++ b/lib/commands/publish/publishChangedPackages.js
@@ -70,8 +70,9 @@ function gitRemoveTaggedVersions(tags) {
   });
 }
 
-function gitPushWithTags() {
-  execSync("git push --follow-tags");
+function gitPushWithTags(tags) {
+  execSync("git push");
+  execSync("git push origin " + tags.join(" "));
 }
 
 function logChangedPackages(packages, versions) {
@@ -127,7 +128,7 @@ module.exports = function publishChangedPackages(
 
     npmPublishSemiAtomic(changedPackages, packagesLoc, versions, function (err) {
       if (err) return onError(err);
-      gitPushWithTags();
+      gitPushWithTags(tags);
       onSuccess();
     });
   } catch (err) {


### PR DESCRIPTION
Somehow `--follow-tags` doesn't always work.

https://github.com/kittens/lerna/issues/52