### PR TITLE
disable progress bar in non-TTY environments

### DIFF
--- a/lib/utils/progressBar.js
+++ b/lib/utils/progressBar.js
@@ -2,6 +2,12 @@ var ProgressBar = require("progress");
 var pad         = require("pad");
 
 module.exports = function progressBar(total) {
+  if (!process.stdout.isTTY) {
+    // Intentionally a noop because node-progress doesn't work well in non-TTY
+    // environments
+    return function tick() {}
+  }
+
   var bar = new ProgressBar(":packagename ╢:bar╟", {
     total: total,
     complete: "█",


### PR DESCRIPTION
If I try to use lerna inside a docker container (and possibly under certain Jenkins configurations), it fails with something `like this.stream.clear() is undefined`. I've found a few reference scattered around the Internet to fix it, but most imply node-progress has already fixed the problem (which is clearly not the case).