### PR TITLE
Fix diff output colors

### DIFF
--- a/lib/commands/diff/index.js
+++ b/lib/commands/diff/index.js
@@ -35,11 +35,7 @@ module.exports = function (config, cli) {
     lastCommit = gitGetFirstCommit();
   }
 
-  var diff = child.spawn("git", ["diff", lastCommit, "--color", filePath]);
-  var pagerOpts = {
-    pager: "less",
-    args: ["-R"] // parse raw control characters
-  };
-
-  diff.stdout.pipe(pager(pagerOpts));
+  child.spawn("git", ["diff", lastCommit, "--color", filePath], {
+    stdio: "inherit"
+  });
 };

--- a/lib/commands/diff/index.js
+++ b/lib/commands/diff/index.js
@@ -36,6 +36,10 @@ module.exports = function (config, cli) {
   }
 
   var diff = child.spawn("git", ["diff", lastCommit, "--color", filePath]);
+  var pagerOpts = {
+    pager: "less",
+    args: ["-R"] // parse raw control characters
+  };
 
-  diff.stdout.pipe(pager());
+  diff.stdout.pipe(pager(pagerOpts));
 };

--- a/lib/commands/diff/index.js
+++ b/lib/commands/diff/index.js
@@ -2,7 +2,6 @@ var gitGetLastTaggedCommit = require("../../utils/gitGetLastTaggedCommit");
 var gitHasTags             = require("../../utils/gitHasTags")
 var execSync               = require("../../utils/execSync");
 var child                  = require("child_process");
-var pager                  = require("default-pager");
 var chalk                  = require("chalk");
 var path                   = require("path");
 var fs                     = require("fs");

--- a/lib/commands/diff/index.js
+++ b/lib/commands/diff/index.js
@@ -34,7 +34,7 @@ module.exports = function (config, cli) {
     lastCommit = gitGetFirstCommit();
   }
 
-  child.spawn("git", ["diff", lastCommit, "--color", filePath], {
+  child.spawn("git", ["diff", lastCommit, "--color=auto", filePath], {
     stdio: "inherit"
   });
 };

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "async": "^1.5.0",
     "chalk": "^1.1.1",
-    "default-pager": "^1.0.2",
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",
     "pad": "^1.0.0",


### PR DESCRIPTION
Without this patch, in OS X `bash`,  `default-pager` outputs a bunch of escaped color codes:

```
ESC[1mdiff --git a/packages/my-awesome-pkg/.npmignore b/packages/my-awesome-pkg/.npmignoreESC[m
ESC[1mnew file mode 100644ESC[m
ESC[1mindex 0000000..281df39ESC[m
ESC[1m--- /dev/nullESC[m
ESC[1m+++ b/packages/my-awesome-pkg/.npmignoreESC[m
ESC[36m@@ -0,0 +1,2 @@ESC[m
ESC[32m+ESC[mESC[32msrcESC[m
ESC[32m+ESC[mESC[32mtestESC[m
ESC[1mdiff --git a/packages/my-awesome-pkg/README.md b/packages/my-awesome-pkg/README.mdESC[m
ESC[1mnew file mode 100644ESC[m
ESC[1mindex 0000000..b326138ESC[m
ESC[1m--- /dev/nullESC[m
ESC[1m+++ b/packages/my-awesome-pkg/README.mdESC[m
ESC[36m@@ -0,0 +1 @@ESC[m
ESC[32m+ESC[mESC[32m# my-awesome-pkgESC[m
```

Providing `less -R` as the pager makes it display the correct colors.

I suppose one could consult `process.env.PAGER` to make sure we aren't overriding user preferences, but that's problematic because `export PAGER='less -R'` doesn't work with `default-pager`'s method of defaulting. We'd have to split the args manually, etc, and that's extremely error prone for very little gain.