### PR TITLE
Do not output info logs during tag updates.

### DIFF
--- a/lib/commands/publish/npmUpdateAsLatest.js
+++ b/lib/commands/publish/npmUpdateAsLatest.js
@@ -12,13 +12,13 @@ module.exports = function npmUpdateAsLatest(changedPackages, versions, callback)
     return function (done) {
       while (true) {
         try {
-          logger.log("info", "Removing temporary npm dist-tag");
+          logger.log("info", "Removing temporary npm dist-tag", true);
           npmUtils.removeDistTag(pkg.name, "lerna-temp");
           if (process.env.NPM_DIST_TAG) {
-            logger.log("info", "Adding " + process.env.NPM_DIST_TAG + " npm dist-tag");
+            logger.log("info", "Adding " + process.env.NPM_DIST_TAG + " npm dist-tag", true);
             npmUtils.addDistTag(pkg.name, versions[pkg.name], process.env.NPM_DIST_TAG);
           } else {
-            logger.log("info", "Adding latest npm dist-tags");
+            logger.log("info", "Adding latest npm dist-tags", true);
             npmUtils.addDistTag(pkg.name, versions[pkg.name], "latest");
           }
           tick(pkg.name);


### PR DESCRIPTION
Fixes #69 in perhaps the most naive way ever. Logging is preserved in case of errors, but otherwise not output during the tag update phase (where the progress bar is more useful feedback).