### PR TITLE
Fix eslint error from deprecated rule space-after-keywords

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,7 +7,7 @@
       "avoid-escape"
     ],
     "no-var": 0,
-    "space-after-keywords": 2,
+    "keyword-spacing": 2,
     "strict": 0,
     "no-underscore-dangle": 0,
     "curly": 0,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "lerna": "./bin/lerna.js"
   },
   "devDependencies": {
-    "eslint": "^1.10.3",
+    "eslint": "^2.3.0",
     "mocha": "^2.4.5"
   }
 }


### PR DESCRIPTION
Fixes eslint errors from a deprecated eslint rule space-after-keywords.  Check out [the docs](http://eslint.org/docs/rules/space-after-keywords) for more details

```
dougwade code/lerna ‹master› » eslint .

/Users/doug.wade/code/lerna/bin/lerna.js
  3:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/index.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/bootstrap/bootstrapPackages.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/bootstrap/index.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/bootstrap/linkDependencies.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/bootstrap/linkDependenciesForPackage.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/diff/index.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/index.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/ls/index.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/publish/index.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/publish/npmPublishAsTemp.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/publish/npmPublishSemiAtomic.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/publish/npmUpdateAsLatest.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/publish/publishChangedPackages.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/publish/updateChangedPackages.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/run/index.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/run/runScriptInPackages.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/commands/updated/index.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/init.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/utils/checkUpdatedPackages.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/utils/execSync.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/utils/exit.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/utils/fsUtils.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/utils/gitUtils.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/utils/logger.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/utils/npmUtils.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/utils/packageUtils.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/lib/utils/progressBar.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

/Users/doug.wade/code/lerna/test/api.js
  1:1  error  Rule 'space-after-keywords' was removed and replaced by: keyword-spacing  space-after-keywords

✖ 29 problems (29 errors, 0 warnings)

dougwade code/lerna ‹master› » git checkout -                                                                                                                                 1 ↵
Switched to branch 'fix-eslint-errors'
dougwade code/lerna ‹fix-eslint-errors› » eslint .
dougwade code/lerna ‹fix-eslint-errors› » eslint -v
v2.3.0
```