### PR TITLE
Create lerna init command

### DIFF
--- a/bin/lerna.js
+++ b/bin/lerna.js
@@ -14,6 +14,7 @@ var cli = meow([
   "  publish    Publish updated packages to npm",
   "  updated    Check which packages have changed since the last release",
   "  diff       Diff all packages or a single package since the last release",
+  "  init       Initialize a lerna repo",
   "  run        Run npm script in each package",
   "  ls         List all public packages",
   "",
@@ -37,9 +38,6 @@ if (!command) {
   cli.showHelp();
 }
 
-var config = init(commandName, process.cwd(), {
-  independent: cli.flags.independent,
-  canary: cli.flags.canary
-});
+var config = init(commandName, process.cwd(), cli.input.slice(1), cli.flags);
 
-command(config, cli);
+command(config);

--- a/lib/commands/bootstrap/bootstrapPackages.js
+++ b/lib/commands/bootstrap/bootstrapPackages.js
@@ -1,8 +1,9 @@
 var linkDependencies = require("./linkDependencies");
 var packageUtils     = require("../../utils/packageUtils");
 
-module.exports = function bootstrapPackages(packagesLoc, currentVersion, flags, callback) {
+module.exports = function bootstrapPackages(packagesLoc, versionLoc, flags, callback) {
   var packages = packageUtils.getPackages(packagesLoc);
+  var currentVersion = packageUtils.getGlobalVersion(versionLoc);
   linkDependencies(packages, packagesLoc, currentVersion, flags, function(err) {
     if (err) return callback(err);
     callback(null, packages);

--- a/lib/commands/bootstrap/index.js
+++ b/lib/commands/bootstrap/index.js
@@ -5,7 +5,7 @@ var exit              = require("../../utils/exit");
 module.exports = function bootstrap(config) {
   bootstrapPackages(
     config.packagesLoc,
-    config.currentVersion,
+    config.versionLoc,
     config.flags,
     function(err, packages) {
       if (err) {

--- a/lib/commands/bootstrap/linkDependenciesForPackage.js
+++ b/lib/commands/bootstrap/linkDependenciesForPackage.js
@@ -1,6 +1,6 @@
 var fsUtils = require("../../utils/fsUtils");
-var async  = require("async");
-var path   = require("path");
+var async   = require("async");
+var path    = require("path");
 
 function createLinkedDepFiles(src, dest, name, callback) {
   fsUtils.writeFile(path.join(dest, "package.json"), JSON.stringify({

--- a/lib/commands/diff/index.js
+++ b/lib/commands/diff/index.js
@@ -5,8 +5,8 @@ var child    = require("child_process");
 var path     = require("path");
 var exit     = require("../../utils/exit");
 
-module.exports = function (config, cli) {
-  var packageName = cli.input[1];
+module.exports = function (config) {
+  var packageName = config.input[1];
   var filePath = "packages";
 
   if (packageName) {

--- a/lib/commands/index.js
+++ b/lib/commands/index.js
@@ -2,5 +2,6 @@ exports.bootstrap = require("./bootstrap");
 exports.publish   = require("./publish");
 exports.updated   = require("./updated");
 exports.diff      = require("./diff");
+exports.init      = require("./init");
 exports.run       = require("./run");
 exports.ls        = require("./ls");

--- a/lib/commands/init/index.js
+++ b/lib/commands/init/index.js
@@ -1,0 +1,37 @@
+var fsUtils = require("../../utils/fsUtils");
+var logger  = require("../../utils/logger");
+
+function ensurePackagesDir(packagesLoc) {
+  if (!fsUtils.existsSync(packagesLoc)) {
+    logger.log("info", "Creating packages folder.");
+    fsUtils.mkdirSync(packagesLoc);
+  }
+}
+
+function ensurePackageJSON(packageLoc, lernaVersion) {
+  if (!fsUtils.existsSync(packageLoc)) {
+    logger.log("info", "Creating package.json.");
+    fsUtils.writeFileSync(packageLoc, JSON.stringify({
+      private: true,
+      dependencies: {
+        lerna: "^" + lernaVersion,
+      }
+    }, null, "  "));
+  }
+}
+
+function ensureVersion(versionLoc) {
+  if (fsUtils.existsSync(versionLoc)) {
+    return fsUtils.readFileSync(versionLoc, "utf8").trim();
+  } else {
+    logger.log("info", "Creating VERSION file.");
+    fsUtils.writeFileSync(versionLoc, "0.0.0");
+    return "0.0.0";
+  }
+}
+
+module.exports = function init(config) {
+  ensurePackagesDir(config.packagesLoc);
+  ensurePackageJSON(config.packageLoc, config.lernaVersion);
+  if (!config.flags.independent) ensureVersion(config.versionLoc);
+};

--- a/lib/commands/publish/index.js
+++ b/lib/commands/publish/index.js
@@ -4,7 +4,6 @@ var exit                   = require("../../utils/exit");
 
 module.exports = function publish(config) {
   publishChangedPackages(
-    config.currentVersion,
     config.versionLoc,
     config.packagesLoc,
     config.flags,

--- a/lib/commands/publish/publishChangedPackages.js
+++ b/lib/commands/publish/publishChangedPackages.js
@@ -1,6 +1,7 @@
 var updateChangedPackages = require("./updateChangedPackages");
 var checkUpdatedPackages  = require("../../utils/checkUpdatedPackages");
 var npmPublishSemiAtomic  = require("./npmPublishSemiAtomic");
+var packageUtils          = require("../../utils/packageUtils");
 var unionWith             = require("lodash.unionwith");
 var readline              = require("readline-sync");
 var gitUtils              = require("../../utils/gitUtils");
@@ -67,7 +68,6 @@ function logChangedPackages(packages, versions) {
 }
 
 module.exports = function publishChangedPackages(
-  currentVersion,
   versionLoc,
   packagesLoc,
   flags,
@@ -77,6 +77,12 @@ module.exports = function publishChangedPackages(
   var masterVersion;
   var versions = {};
   var tags;
+
+  var currentVersion = packageUtils.getGlobalVersion(versionLoc);
+
+  if (currentVersion) {
+    logger.log("info", "Current version: " + currentVersion);
+  }
 
   try {
     // Find all changed packages to publish

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,70 +1,44 @@
 var fsUtils = require("./utils/fsUtils");
 var logger  = require("./utils/logger");
 var path    = require("path");
+var exit    = require("./utils/exit");
 
-function ensurePackagesDir(packagesLoc) {
-  if (!fsUtils.existsSync(packagesLoc)) {
-    logger.log("info", "Creating packages folder.");
-    fsUtils.mkdirSync(packagesLoc);
-  }
-}
+module.exports = function init(command, cwd, input, flags) {
+  var lernaVersion = require("../package.json").version;
 
-function ensurePackageJSON(packageLoc, lernaVersion) {
-  if (!fsUtils.existsSync(packageLoc)) {
-    logger.log("info", "Creating package.json");
-    fsUtils.writeFileSync(packageLoc, JSON.stringify({
-      private: true,
-      dependencies: {
-        lerna: "^" + lernaVersion,
-      }
-    }, null, "  "));
-  }
-}
+  logger.log("info", "Lerna " + command +  " v" + lernaVersion);
 
-function ensureVersion(versionLoc) {
-  if (fsUtils.existsSync(versionLoc)) {
-    return fsUtils.readFileSync(versionLoc, "utf8").trim();
-  } else {
-    logger.log("info", "Creating VERSION file.");
-    fsUtils.writeFileSync(versionLoc, "0.0.0");
-    return "0.0.0";
-  }
-}
+  if (flags.independent) logger.log("info", "Independent Versioning Mode");
+  if (flags.canary) logger.log("info", "Publishing canary build");
 
-module.exports = function init(cmd, cwd, flags) {
-  var version = require("../package.json").version;
+  var packagesLoc = path.join(cwd, "packages");
+  var packageLoc = path.join(cwd, "package.json");
+  var versionLoc = path.join(cwd, "VERSION");
 
-  logger.log("info", "Lerna " + cmd +  " v" + version);
+  if (command !== "init") {
+    if (!fsUtils.existsSync(packagesLoc)) {
+      logger.log("error", "`packages/` directory does not exist, have you run `lerna init`?");
+      exit(1);
+    }
 
-  if (flags.independent) {
-    logger.log("info", "Independent Versioning Mode");
+    if (!fsUtils.existsSync(packageLoc)) {
+      logger.log("error", "`package.json` does not exist, have you run `lerna init`?");
+      exit(1);
+    }
+
+    if (!flags.independent && !fsUtils.existsSync(versionLoc)) {
+      logger.log("error", "`VERSION` does not exist, have you run `lerna init`? Or maybe you meant to run this with `--independent` or `-i`?");
+      exit(1);
+    }
   }
 
-  if (flags.canary) {
-    logger.log("info", "Publishing canary build");
-  }
-
-  var config = {};
-
-  config.flags = flags;
-
-  config.packagesLoc = path.join(cwd, "packages");
-  config.packageLoc  = path.join(cwd, "package.json");
-
-  if (!flags.independent) {
-    config.versionLoc     = path.join(cwd, "VERSION");
-    config.currentVersion = ensureVersion(config.versionLoc);
-  }
-
-  ensurePackagesDir(config.packagesLoc);
-  ensurePackageJSON(config.packageLoc, version);
-
-  if (!flags.independent) {
-    logger.log("info", "Current version: " + config.currentVersion);
-    logger.log("info", "Version file location: " + config.versionLoc);
-  }
-
-  logger.log("info", "Packages location: " + config.packagesLoc);
-
-  return config;
+  return {
+    lernaVersion: lernaVersion,
+    packagesLoc: packagesLoc,
+    packageLoc: packageLoc,
+    versionLoc: versionLoc,
+    command: command,
+    input: input,
+    flags: flags
+  };
 };

--- a/lib/utils/packageUtils.js
+++ b/lib/utils/packageUtils.js
@@ -1,6 +1,12 @@
 var fsUtils = require("./fsUtils");
 var path    = require("path");
 
+function getGlobalVersion(versionLoc) {
+  if (fsUtils.existsSync(versionLoc)) {
+    return fsUtils.readFileSync(versionLoc, "utf8").trim();
+  }
+}
+
 function getPackagesPath(rootPath) {
   return path.join(rootPath, "packages");
 }
@@ -42,6 +48,7 @@ function getPackages(packagesPath) {
 }
 
 module.exports = {
+  getGlobalVersion: getGlobalVersion,
   getPackagesPath: getPackagesPath,
   getPackagePath: getPackagePath,
   getPackageConfigPath: getPackageConfigPath,


### PR DESCRIPTION
Resolves #47

This will simplify a lot of things that I want to do soon like `lerna.json`, then once `lerna.json` is in we won't have to use the `cwd` anymore and we can recursively look up the tree to find a `lerna.json` or `package.json` with a `lerna` field.

This also improves the experience of `--independent`, see the warning in `lib/init.js`.

```
`VERSION` does not exist, have you run `lerna init`? Or maybe you meant to run this with `--independent` or `-i`?
```