### PR TITLE
Add -a to 'git commit'

### DIFF
--- a/lib/utils/gitUtils.js
+++ b/lib/utils/gitUtils.js
@@ -7,7 +7,7 @@ var addFile = logger.logifySync("gitUtils.addFile", function (file) {
 
 var commit = logger.logifySync("gitUtils.commit", function (message) {
   // Use echo to allow multi\nline strings.
-  execSync("git commit -m \"$(echo \"" + message + "\")\"");
+  execSync("git commit -a -m \"$(echo \"" + message + "\")\"");
 });
 
 var addTag = logger.logifySync("gitUtils.addTag", function (tag) {


### PR DESCRIPTION
This is useful if you want to integrate lerna with other services.

I'm running [conventional-changelog-cli](https://github.com/stevemao/conventional-changelog-cli) and then `lerna`. With this change, `lerna` will include the changelog in it's version commit.
