### PR TITLE
Install only external dependencies during bootstrap

### DIFF
--- a/lib/commands/bootstrap/hasMatchingDependency.js
+++ b/lib/commands/bootstrap/hasMatchingDependency.js
@@ -1,0 +1,22 @@
+module.exports = function hasMatchingDependency(pkg, dep) {
+  var version = false;
+
+  if (pkg.pkg.dependencies) {
+    version = pkg.pkg.dependencies[dep.name];
+  }
+
+  if (pkg.pkg.devDependencies && !version) {
+    version = pkg.pkg.devDependencies[dep.name];
+  }
+
+  if (!version) {
+    return false;
+  }
+
+  // ensure that this is referring to a local package
+  if (version[0] !== "^" || version[1] !== dep.version[0]) {
+    return false;
+  }
+
+  return true;
+};

--- a/lib/commands/bootstrap/installExternalPackages.js
+++ b/lib/commands/bootstrap/installExternalPackages.js
@@ -1,0 +1,29 @@
+var hasMatchingDependency = require("./hasMatchingDependency");
+var npmUtils              = require("../../utils/npmUtils");
+var find                  = require("lodash.find");
+
+module.exports = function installExternalPackages(packageLoc, pkg, packages, callback) {
+  var deps = Object.keys(pkg.pkg.dependencies);
+  var devDeps = Object.keys(pkg.pkg.devDependencies);
+
+  var externalPackages = deps.concat(devDeps).filter(function(dep) {
+    var match = find(packages, function(p) {
+      return p.name === dep;
+    });
+
+    return !(match && hasMatchingDependency(pkg, match));
+  });
+
+  var toInstall = externalPackages.map(function(dep) {
+    var version;
+    if (pkg.pkg.dependencies) version = pkg.pkg.dependencies[dep];
+    if (pkg.pkg.devDependencies && !version) version = pkg.pkg.devDependencies[dep];
+    return dep + '@' + version;
+  });
+
+  if (toInstall.length) {
+    npmUtils.installInDir(packageLoc, toInstall, callback);
+  } else {
+    callback();
+  }
+};

--- a/lib/commands/bootstrap/installExternalPackages.js
+++ b/lib/commands/bootstrap/installExternalPackages.js
@@ -6,19 +6,19 @@ module.exports = function installExternalPackages(packageLoc, pkg, packages, cal
   var deps = Object.keys(pkg.pkg.dependencies);
   var devDeps = Object.keys(pkg.pkg.devDependencies);
 
-  var externalPackages = deps.concat(devDeps).filter(function(dep) {
-    var match = find(packages, function(p) {
+  var externalPackages = deps.concat(devDeps).filter(function (dep) {
+    var match = find(packages, function (p) {
       return p.name === dep;
     });
 
     return !(match && hasMatchingDependency(pkg, match));
   });
 
-  var toInstall = externalPackages.map(function(dep) {
+  var toInstall = externalPackages.map(function (dep) {
     var version;
     if (pkg.pkg.dependencies) version = pkg.pkg.dependencies[dep];
     if (pkg.pkg.devDependencies && !version) version = pkg.pkg.devDependencies[dep];
-    return dep + '@' + version;
+    return dep + "@" + version;
   });
 
   if (toInstall.length) {

--- a/lib/commands/bootstrap/linkDependencies.js
+++ b/lib/commands/bootstrap/linkDependencies.js
@@ -1,6 +1,6 @@
 var linkDependenciesForPackage = require("./linkDependenciesForPackage");
+var installExternalPackages    = require("./installExternalPackages");
 var progressBar                = require("../../utils/progressBar");
-var npmUtils                   = require("../../utils/npmUtils");
 var fsUtils                    = require("../../utils/fsUtils");
 var logger                     = require("../../utils/logger");
 var async                      = require("async");
@@ -29,12 +29,12 @@ module.exports = function linkDependencies(
       });
 
       tasks.push(function (done) {
-        npmUtils.installInDir(packageLoc, done);
+        installExternalPackages(packageLoc, root, packages, done);
       });
 
       tasks.push(function (done) {
         linkDependenciesForPackage(
-          root.pkg,
+          root,
           packages,
           packagesLoc,
           nodeModulesLoc,

--- a/lib/commands/bootstrap/linkDependenciesForPackage.js
+++ b/lib/commands/bootstrap/linkDependenciesForPackage.js
@@ -1,6 +1,7 @@
-var fsUtils = require("../../utils/fsUtils");
-var async   = require("async");
-var path    = require("path");
+var hasMatchingDependency = require("./hasMatchingDependency");
+var fsUtils               = require("../../utils/fsUtils");
+var async                 = require("async");
+var path                  = require("path");
 
 function createLinkedDepFiles(src, dest, name, callback) {
   fsUtils.writeFile(path.join(dest, "package.json"), JSON.stringify({
@@ -38,15 +39,7 @@ module.exports = function linkDependenciesForPackage(
   callback
 ) {
   async.each(packages, function (sub, done) {
-    var ver = false;
-    if (pkg.dependencies) ver = pkg.dependencies[sub.name];
-    if (pkg.devDependencies && !ver) ver = pkg.devDependencies[sub.name];
-    if (!ver) return done();
-
-    var matchedVersion = flags.independent ? sub.version : currentVersion;
-
-    // ensure that this is referring to a local package
-    if (ver[0] !== "^" || ver[1] !== matchedVersion[0]) return done();
+    if (!hasMatchingDependency(pkg, sub)) return done();
 
     var linkSrc = path.join(packagesLoc, sub.folder);
     var linkDest = path.join(nodeModulesLoc, sub.name);

--- a/lib/utils/logger.js
+++ b/lib/utils/logger.js
@@ -67,16 +67,16 @@ function logifyAsync(message, method) {
       args[i] = arguments[i];
     }
 
-    message = formatMethod(message, args);
+    var msg = formatMethod(message, args);
 
-    log("info", message, true);
+    log("info", msg, true);
 
     // wrap final callback
     args[length - 1] = function(error, value) {
       if (error) {
-        log("error", message, true);
+        log("error", msg, true);
       } else {
-        log("success", message + " => " + formatArg(value), true);
+        log("success", msg + " => " + formatArg(value), true);
       }
 
       callback.apply(null, arguments);
@@ -95,16 +95,16 @@ function logifySync(message, method) {
       args[i] = arguments[i];
     }
 
-    message = formatMethod(message, args);
+    var msg = formatMethod(message, args);
 
-    log("info", message, true);
+    log("info", msg, true);
 
     try {
       var result = method.apply(null, args);
-      log("success", message + " => " + formatArg(result), true);
+      log("success", msg + " => " + formatArg(result), true);
       return result;
     } catch (error) {
-      log("error", message, true, error);
+      log("error", msg, true, error);
       throw error;
     }
   };

--- a/lib/utils/npmUtils.js
+++ b/lib/utils/npmUtils.js
@@ -2,8 +2,14 @@ var execSync = require("./execSync");
 var logger   = require("./logger");
 var child    = require("child_process");
 
-var installInDir = logger.logifyAsync("npmUtils.installInDir", function (dir, callback) {
-  child.exec("npm install", {
+var installInDir = logger.logifyAsync("npmUtils.installInDir", function (dir, deps, callback) {
+  var command = "npm install";
+
+  if (deps) {
+    command += " " + deps.join(" ");
+  }
+
+  child.exec(command, {
     cwd: dir
   }, function (err, stdout, stderr) {
     if (err != null) {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "async": "^1.5.0",
     "chalk": "^1.1.1",
     "inquirer": "^0.12.0",
+    "lodash.find": "^4.3.0",
     "lodash.unionwith": "^4.2.0",
     "meow": "^3.7.0",
     "mkdirp": "^0.5.1",


### PR DESCRIPTION
Fixes #79 and #59

I also fixed a problem with the logger and an issue with how we match dependencies that should be "linked".

This allows you to create new dependencies that don't exist on npm yet.

This might also open up the possibility of doing actual symlinks because we are explicitly installing only external deps.