### PR TITLE
fix(init): lerna.json does not exist in empty repository

### DIFF
--- a/src/commands/InitCommand.js
+++ b/src/commands/InitCommand.js
@@ -58,7 +58,7 @@ export default class InitCommand extends Command {
       version = "independent";
     } else if (FileSystemUtilities.existsSync(versionLocation)) {
       version = FileSystemUtilities.readFileSync(versionLocation);
-    } else if (lernaJson.version) {
+    } else if (lernaJson && lernaJson.version) {
       version = lernaJson.version;
     } else {
       version = "0.0.0";


### PR DESCRIPTION
`lerna init` with `2.0.0-beta.7` fails in an empty repository:

```
$ lerna init
Lerna v2.0.0-beta.7
Updating package.json.
Errored while running InitCommand.execute
TypeError: Cannot read property 'version' of undefined
    at InitCommand.ensureLernaJson (/usr/local/lib/node_modules/lerna/lib/commands/InitCommand.js:111:27)
    at InitCommand.execute (/usr/local/lib/node_modules/lerna/lib/commands/InitCommand.js:58:12)
    at InitCommand._attempt (/usr/local/lib/node_modules/lerna/lib/Command.js:148:21)
    at /usr/local/lib/node_modules/lerna/lib/Command.js:133:15
    at /usr/local/lib/node_modules/lerna/lib/Command.js:157:13
    at InitCommand.initialize (/usr/local/lib/node_modules/lerna/lib/commands/InitCommand.js:51:7)
    at InitCommand._attempt (/usr/local/lib/node_modules/lerna/lib/Command.js:148:21)
    at InitCommand.runCommand (/usr/local/lib/node_modules/lerna/lib/Command.js:132:12)
    at InitCommand.run (/usr/local/lib/node_modules/lerna/lib/Command.js:62:12)
    at Object.<anonymous> (/usr/local/lib/node_modules/lerna/bin/lerna.js:44:11)
```

due to `lernaJson` not available.