### PR TITLE
fix: `lerna diff` for repositories without commits

### DIFF
--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -73,4 +73,9 @@ export default class GitUtilities {
   static getCurrentBranch() {
     return ChildProcessUtilities.execSync("git symbolic-ref --short HEAD");
   }
+
+  @logger.logifySync
+  static hasCommit() {
+    return ChildProcessUtilities.execSync("git log");
+  }
 }

--- a/src/GitUtilities.js
+++ b/src/GitUtilities.js
@@ -76,6 +76,11 @@ export default class GitUtilities {
 
   @logger.logifySync
   static hasCommit() {
-    return ChildProcessUtilities.execSync("git log");
+    try {
+      ChildProcessUtilities.execSync("git log");
+      return true;
+    } catch (e) {
+      return false;
+    }
   }
 }

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -18,6 +18,11 @@ export default class DiffCommand extends Command {
       }
     }
 
+    if (!GitUtilities.hasCommit()) {
+      callback(new Error("Can't diff. There are no commits in this repository, yet."));
+      return;
+    }
+
     this.filePath = this.package
       ? this.package.location
       : this.repository.packagesLocation;
@@ -37,16 +42,5 @@ export default class DiffCommand extends Command {
         callback(null, true);
       }
     });
-  }
-
-  runValidations() {
-    super.runValidations();
-    try {
-      GitUtilities.hasCommit();
-    } catch (err) {
-      this.logger.warning("Can't diff. There are no commits in this repository, yet.");
-      this._complete(err, 1);
-      return;
-    }
   }
 }

--- a/src/commands/DiffCommand.js
+++ b/src/commands/DiffCommand.js
@@ -38,4 +38,15 @@ export default class DiffCommand extends Command {
       }
     });
   }
+
+  runValidations() {
+    super.runValidations();
+    try {
+      GitUtilities.hasCommit();
+    } catch (err) {
+      this.logger.warning("Can't diff. There are no commits in this repository, yet.");
+      this._complete(err, 1);
+      return;
+    }
+  }
 }

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -51,20 +51,19 @@ describe("DiffCommand", () => {
   });
 
   it("should error when running in a repository without commits", (done) => {
-    const noCommitsError = new Error("fatal: your current branch 'master' does not have any commits yet");
     const diffCommand = new DiffCommand(["package-1"], {});
+
+    diffCommand.runValidations();
+    diffCommand.runPreparations();
 
     stub(ChildProcessUtilities, "execSync", (command) => {
       assert.equal(command, "git log");
-      throw noCommitsError;
+      throw new Error("fatal: your current branch 'master' does not have any commits yet");
     });
 
-    stub(diffCommand, "_complete", (err, code) => {
-      assert.equal(err, noCommitsError);
-      assert.equal(code, 1);
+    diffCommand.initialize((err) => {
+      assert.equal(err.message, "Can't diff. There are no commits in this repository, yet.");
       done();
     });
-
-    diffCommand.runValidations();
   });
 });

--- a/test/DiffCommand.js
+++ b/test/DiffCommand.js
@@ -49,4 +49,22 @@ describe("DiffCommand", () => {
 
     diffCommand.runCommand(exitWithCode(0, done));
   });
+
+  it("should error when running in a repository without commits", (done) => {
+    const noCommitsError = new Error("fatal: your current branch 'master' does not have any commits yet");
+    const diffCommand = new DiffCommand(["package-1"], {});
+
+    stub(ChildProcessUtilities, "execSync", (command) => {
+      assert.equal(command, "git log");
+      throw noCommitsError;
+    });
+
+    stub(diffCommand, "_complete", (err, code) => {
+      assert.equal(err, noCommitsError);
+      assert.equal(code, 1);
+      done();
+    });
+
+    diffCommand.runValidations();
+  });
 });

--- a/test/GitUtilities.js
+++ b/test/GitUtilities.js
@@ -85,4 +85,10 @@ describe("GitUtilities", () => {
       assert.ok(GitUtilities.checkoutChanges);
     });
   });
+
+  describe(".hasCommit()", () => {
+    it("should exist", () => {
+      assert.ok(GitUtilities.hasCommit);
+    });
+  });
 });


### PR DESCRIPTION
`lerna diff` on a repository without any commits fails due to:
```console
$ lerna diff
Lerna v2.0.0-beta.7
Independent Versioning Mode
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Errored while running DiffCommand.initialize
Error: Command failed: git rev-list --max-parents=0 HEAD
fatal: ambiguous argument 'HEAD': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

    at checkExecSyncError (child_process.js:470:13)
    at Object.execSync (child_process.js:510:13)
    at Function.execSync (/usr/local/lib/node_modules/lerna/lib/ChildProcessUtilities.js:37:38)
    at Function.getFirstCommit (/usr/local/lib/node_modules/lerna/lib/GitUtilities.js:92:46)
    at DiffCommand.initialize (/usr/local/lib/node_modules/lerna/lib/commands/DiffCommand.js:63:130)
    at DiffCommand._attempt (/usr/local/lib/node_modules/lerna/lib/Command.js:148:21)
    at DiffCommand.runCommand (/usr/local/lib/node_modules/lerna/lib/Command.js:132:12)
    at DiffCommand.run (/usr/local/lib/node_modules/lerna/lib/Command.js:62:12)
    at Object.<anonymous> (/usr/local/lib/node_modules/lerna/bin/lerna.j%
```
currently.